### PR TITLE
Enhance SEO metadata integration in blog post template by moving useH…

### DIFF
--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -40,7 +40,55 @@ onBeforeMount(async () => {
         isLoading.value = true
         await postsStore.fetchPosts()
         isLoading.value = false
+        useHead({
+            htmlAttrs: { lang: 'en-US' }, // BCP 47 language code
+            link: [{
+                rel: 'canonical',
+                href: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`,
+                content: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`
+            }]
+        })
 
+        useSeoMeta({
+            title: selectedPost.value?.title,
+            // titleTemplate: '%s',
+            description: selectedPost.value?.excerpt,
+            ogType: 'article',
+            articlePublishedTime: selectedPost.value?.publishedAt,
+            articleModifiedTime: selectedPost.value?._updatedAt,
+            articleAuthor: selectedPost.value?.authorInfo.name,
+            // articleSection: 'Technology', // category
+            articleTag: tags.value,
+            twitterLabel1: 'Author',
+            twitterData1: selectedPost.value?.authorInfo.name,
+            ogUrl: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`,
+            ogLocale: 'en_US',
+            ogSiteName: defaultSiteSettings.siteName,
+            twitterTitle: selectedPost.value?.title,
+            twitterDescription: selectedPost.value?.excerpt,
+
+            // no longer explicitly used by X but may be useful for SEO
+            // twitterSite: '@example',
+            // twitterCreator: '@example',
+
+            // og image
+            ogImage: {
+                url: selectedPost.value?.imgUrl,
+                width: 1400,
+                height: 750,
+                alt: selectedPost.value?.title,
+                type: 'image/png'
+            },
+            twitterImage: {
+                url: selectedPost.value?.imgUrl,
+                width: 1400,
+                height: 750,
+                alt: selectedPost.value?.title,
+                type: 'image/png'
+            },
+            // twitter image (note: ogImage is used as a fallback so this is optional)
+            twitterCard: 'summary_large_image', // or summary
+        })
     } catch (error) {
         toast.error(generateHumanMessage(`${error}`), {
             duration: 5000, action: {
@@ -58,55 +106,7 @@ onBeforeMount(async () => {
 
 
 })
-useHead({
-    htmlAttrs: { lang: 'en-US' }, // BCP 47 language code
-    link: [{
-        rel: 'canonical',
-        href: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`,
-        content: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`
-    }]
-})
 
-useSeoMeta({
-    title: selectedPost.value?.title,
-    // titleTemplate: '%s',
-    description: selectedPost.value?.excerpt,
-    ogType: 'article',
-    articlePublishedTime: selectedPost.value?.publishedAt,
-    articleModifiedTime: selectedPost.value?._updatedAt,
-    articleAuthor: selectedPost.value?.authorInfo.name,
-    // articleSection: 'Technology', // category
-    articleTag: tags.value,
-    twitterLabel1: 'Author',
-    twitterData1: selectedPost.value?.authorInfo.name,
-    ogUrl: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`,
-    ogLocale: 'en_US',
-    ogSiteName: defaultSiteSettings.siteName,
-    twitterTitle: selectedPost.value?.title,
-    twitterDescription: selectedPost.value?.excerpt,
-
-    // no longer explicitly used by X but may be useful for SEO
-    // twitterSite: '@example',
-    // twitterCreator: '@example',
-
-    // og image
-    ogImage: {
-        url: selectedPost.value?.imgUrl,
-        width: 1400,
-        height: 750,
-        alt: selectedPost.value?.title,
-        type: 'image/png'
-    },
-    twitterImage: {
-        url: selectedPost.value?.imgUrl,
-        width: 1400,
-        height: 750,
-        alt: selectedPost.value?.title,
-        type: 'image/png'
-    },
-    // twitter image (note: ogImage is used as a fallback so this is optional)
-    twitterCard: 'summary_large_image', // or summary
-})
 
 </script>
 <template>


### PR DESCRIPTION
…ead and useSeoMeta calls into the onBeforeMount lifecycle hook. This improves data fetching timing and ensures accurate metadata for social media sharing, including Open Graph and Twitter card details.

## Summary by Sourcery

Enhance SEO metadata setup for blog posts by moving head and SEO meta calls into the onBeforeMount hook to ensure metadata is populated after post data is fetched.

Enhancements:
- Move useHead and useSeoMeta invocation into onBeforeMount after data fetch to improve metadata timing.
- Ensure canonical link, language attribute, Open Graph and Twitter card details are generated using the loaded post data.