### PR TITLE
Update SEO metadata URLs in blog templates for consistency and clarit…

### DIFF
--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -105,7 +105,7 @@ whenever(() => selectedPost.value, () => {
         articleTag: tags.value,
         twitterLabel1: 'Author',
         twitterData1: selectedPost.value?.authorInfo.name,
-        ogUrl: `${defaultSiteSettings.siteUrl}/blog/${selectedPost.value?.slug}`,
+        ogUrl: defaultSiteSettings.siteUrl,
         ogLocale: 'en_US',
         ogSiteName: defaultSiteSettings.siteName,
         twitterTitle: selectedPost.value?.title,
@@ -119,14 +119,14 @@ whenever(() => selectedPost.value, () => {
         ogImage: {
             url: selectedPost.value?.imgUrl,
             width: 1400,
-            height: 750,
+            height: 700,
             alt: selectedPost.value?.title,
             type: 'image/png'
         },
         twitterImage: {
             url: selectedPost.value?.imgUrl,
             width: 1400,
-            height: 750,
+            height: 700,
             alt: selectedPost.value?.title,
             type: 'image/png'
         },

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -17,7 +17,7 @@ useSeoMeta({
     titleTemplate: '%s',
     description: 'My blog posts and tech experiences',
     ogType: 'website',
-    ogUrl: `${defaultSiteSettings.siteUrl}/blog`,
+    ogUrl: defaultSiteSettings.siteUrl,
     ogLocale: 'en_US',
     ogSiteName: defaultSiteSettings.siteName,
     twitterTitle: 'Michael Nji - Blog',
@@ -29,14 +29,14 @@ useSeoMeta({
 
     // og image
     ogImage: {
-        url: `${defaultSiteSettings.siteUrl}/seo/og-image-blog.png`,
+        url: '/seo/og-image-blog.png',
         width: 1200,
         height: 800,
         alt: `Blog page of ${defaultSiteSettings.siteName}`,
         type: 'image/png'
     },
     twitterImage: {
-        url: `${defaultSiteSettings.siteUrl}/seo/og-image-blog.png`,
+        url: '/seo/og-image-blog.png',
         width: 1200,
         height: 800,
         alt: `Blog page of ${defaultSiteSettings.siteName}`,


### PR DESCRIPTION
…y. Change Open Graph URLs to use the base site URL and adjust image dimensions for better display on social media platforms.

## Summary by Sourcery

Standardize SEO metadata in blog templates by using the site root URL and refining image configurations for social sharing

Enhancements:
- Use the base site URL for Open Graph URLs in both blog index and post pages
- Convert blog index OG and Twitter image paths to relative asset URLs
- Reduce OG and Twitter image height in post pages from 750px to 700px