### PR TITLE
Fix typo in Hero component by correcting "Supaase" to "Supabase" for …

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -168,7 +168,7 @@ const currentSection = computed(() => {
                     </span>
                     <span
                         class="!py-1 px-3 rounded-lg bg-base-200  inline-flex shadow-xl border-1 border-dashed text-sm border-base-content/30 font-mono flex items-center gap-2 ">
-                        <Icon name="logos:supabase-icon" />Supaase
+                        <Icon name="logos:supabase-icon" />Supabase
                     </span>
                     <span
                         class="!py-1 px-3 rounded-lg bg-base-200  inline-flex shadow-xl border-1 border-dashed text-sm border-base-content/30 font-mono flex items-center gap-2 ">


### PR DESCRIPTION
…improved clarity.

## Summary by Sourcery

Bug Fixes:
- Correct typo in Hero component by replacing 'Supaase' with 'Supabase'.