### PR TITLE
refactor: move Biome badge out of NuxtLink and remove redundant flex …

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -100,12 +100,12 @@ const currentSection = computed(() => {
                         <span class="underline text-primary">
                             the documentation of
                         </span>
-                        <span
-                            class="!py-1 px-3 rounded-lg bg-base-200  inline-flex shadow-xl border-1 border-dashed text-sm border-base-content/30 font-mono flex items-center gap-2 ">
-                            <Icon name="logos:biomejs-icon" /> Biome
-                        </span>
+
                     </span>
-                </NuxtLink> ,
+                </NuxtLink> <span
+                    class="!py-1 px-3 rounded-lg bg-base-200  inline-flex shadow-xl border-1 border-dashed text-sm border-base-content/30 font-mono  items-center gap-2 ">
+                    <Icon name="logos:biomejs-icon" /> Biome
+                </span> ,
                 a fast javascript linter and formatter, and <NuxtLink @click="playSound"
                     to="https://github.com/michaelnji/test-stepci-and-circleci-integration" target="_blank">
 


### PR DESCRIPTION
…class.

## Summary by Sourcery

Refine the Hero section link layout by separating the Biome badge from the NuxtLink and simplifying its styling.

Enhancements:
- Move the Biome badge outside the NuxtLink to improve link semantics and layout.
- Remove redundant flex styling from the Biome badge container for cleaner markup.