### PR TITLE
feat: Add sticky header and compact blog stats section layout.

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -67,7 +67,8 @@ onMounted(async () => {
       class: '!p-3 !rounded-box  !items-start  ',
       descriptionClass: 'text-sm '
     }" />
-    <div class="w-full px-6 py-3 border-b border-base-300 flex justify-between items-center gap-x-4 bg-base-200 ">
+    <div
+      class="w-full px-6 py-3 border-b border-base-300 flex justify-between sticky top-0 z-1000 items-center gap-x-4 bg-base-200 ">
       <Logo />
 
       <div class="flex items-center gap-x-4">

--- a/components/BlogStatsSection.vue
+++ b/components/BlogStatsSection.vue
@@ -88,97 +88,112 @@ const loadingCards = [1, 2, 3, 4, 5]
              <div class="h-px bg-base-content/20 flex-1"></div>
         </div>
 
-        <div v-if="isLoading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-             <div v-for="i in loadingCards" :key="i" class="skeleton h-48 rounded-3xl"></div>
+        <div v-if="isLoading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div v-for="i in loadingCards" :key="i" class="skeleton h-40 rounded-3xl"></div>
         </div>
 
-        <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             <!-- Total Stats -->
             <div
-                class="p-8 md:col-span-2 lg:col-span-3 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
+                class="p-5 md:col-span-2 lg:col-span-3 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
                 <div
-                    class="w-14 h-14 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-secondary/10 text-secondary">
-                    <Icon name="solar:chart-square-bold" size="32" />
+                    class="w-12 h-12 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-secondary/10 text-secondary">
+                    <Icon name="solar:chart-square-bold" size="24" />
                 </div>
-                <div class="mt-4">
-                    <h3 class="text-sm font-medium uppercase tracking-wider opacity-60">All Time Stats</h3>
-                    <div class="text-3xl font-bold mt-2">{{ totalStats.views }} Total Views</div>
-                    <div class="mt-4 flex items-center gap-2">
-                        <Icon name="solar:star-bold-duotone" class="text-warning" size="24" />
-                        <span class="text-xl font-bold">{{ totalStats.totalReactions }}</span>
-                        <span class="text-sm font-medium opacity-60 uppercase tracking-wider">Reactions</span>
+                <div class="mt-2">
+                    <h3 class="text-xs font-medium uppercase tracking-wider opacity-60">All Time Stats</h3>
+                    <div class="text-2xl font-bold mt-1">{{ totalStats.views }} Total Views</div>
+                    <div class="mt-2 flex items-center gap-2">
+                        <Icon name="solar:star-bold-duotone" class="text-warning" size="20" />
+                        <span class="text-lg font-bold">{{ totalStats.totalReactions }}</span>
+                        <span class="text-xs font-medium opacity-60 uppercase tracking-wider">Reactions</span>
                     </div>
                 </div>
             </div>
             <!-- Most Popular -->
-            <NuxtLink v-if="mostPopular?.post" :to="`/blog/${mostPopular.post.slug}`" class="p-8 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
-                <div class="w-14 h-14 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-primary/10 text-primary">
-                    <Icon name="solar:eye-bold" size="32" />
+            <NuxtLink v-if="mostPopular?.post" :to="`/blog/${mostPopular.post.slug}`"
+                class="p-5 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
+                <div
+                    class="w-12 h-12 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-primary/10 text-primary">
+                    <Icon name="solar:eye-bold" size="24" />
                 </div>
-                <div class="mt-4">
-                    <h3 class="text-sm font-medium uppercase tracking-wider opacity-60">Most Popular</h3>
-                    <div class="text-3xl font-bold mt-2">{{ mostPopular.stat?.views ?? 0 }} Views</div>
-                    <p class="mt-2 text-lg font-medium group-hover:text-primary transition-colors line-clamp-2">{{ mostPopular.post.title }}</p>
+                <div class="mt-2">
+                    <h3 class="text-xs font-medium uppercase tracking-wider opacity-60">Most Popular</h3>
+                    <div class="text-2xl font-bold mt-1">{{ mostPopular.stat?.views ?? 0 }} Views</div>
+                    <p class="mt-1 text-base font-medium group-hover:text-primary transition-colors line-clamp-2">{{
+                        mostPopular.post.title }}</p>
                 </div>
             </NuxtLink>
 
              <!-- Most Liked -->
-            <NuxtLink v-if="mostLiked?.post" :to="`/blog/${mostLiked.post.slug}`" class="p-8 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
-                <div class="w-14 h-14 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-error/10 text-error">
-                    <Icon name="solar:heart-bold" size="32" />
+            <NuxtLink v-if="mostLiked?.post" :to="`/blog/${mostLiked.post.slug}`"
+                class="p-5 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
+                <div
+                    class="w-12 h-12 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-error/10 text-error">
+                    <Icon name="solar:heart-bold" size="24" />
                 </div>
-                <div class="mt-4">
-                    <h3 class="text-sm font-medium uppercase tracking-wider opacity-60">Most Liked</h3>
-                    <div class="text-3xl font-bold mt-2">{{ mostLiked.stat?.hearts ?? 0 }} Hearts</div>
-                    <p class="mt-2 text-lg font-medium group-hover:text-primary transition-colors line-clamp-2">{{ mostLiked.post.title }}</p>
+                <div class="mt-2">
+                    <h3 class="text-xs font-medium uppercase tracking-wider opacity-60">Most Liked</h3>
+                    <div class="text-2xl font-bold mt-1">{{ mostLiked.stat?.hearts ?? 0 }} Hearts</div>
+                    <p class="mt-1 text-base font-medium group-hover:text-primary transition-colors line-clamp-2">{{
+                        mostLiked.post.title }}</p>
                 </div>
             </NuxtLink>
 
             <!-- Most Disliked -->
-            <NuxtLink v-if="mostDisliked?.post" :to="`/blog/${mostDisliked.post.slug}`" class="p-8 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
-                <div class="w-14 h-14 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-base-content/10 text-base-content/70">
-                    <Icon name="solar:like-bold" class="transform rotate-180" size="32" />
+            <NuxtLink v-if="mostDisliked?.post" :to="`/blog/${mostDisliked.post.slug}`"
+                class="p-5 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
+                <div
+                    class="w-12 h-12 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-base-content/10 text-base-content/70">
+                    <Icon name="solar:like-bold" class="transform rotate-180" size="24" />
                 </div>
-                <div class="mt-4">
-                     <h3 class="text-sm font-medium uppercase tracking-wider opacity-60">Most Disliked</h3>
-                    <div class="text-3xl font-bold mt-2">{{ mostDisliked.stat?.dislikes ?? 0 }} Dislikes</div>
-                    <p class="mt-2 text-lg font-medium group-hover:text-primary transition-colors line-clamp-2">{{ mostDisliked.post.title }}</p>
+                <div class="mt-2">
+                    <h3 class="text-xs font-medium uppercase tracking-wider opacity-60">Most Disliked</h3>
+                    <div class="text-2xl font-bold mt-1">{{ mostDisliked.stat?.dislikes ?? 0 }} Dislikes</div>
+                    <p class="mt-1 text-base font-medium group-hover:text-primary transition-colors line-clamp-2">{{
+                        mostDisliked.post.title }}</p>
                 </div>
             </NuxtLink>
 
             <!-- Oldest Post -->
-            <NuxtLink v-if="oldestPost?.post" :to="`/blog/${oldestPost.post.slug}`" class="p-8 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
-                 <div class="w-14 h-14 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-warning/10 text-warning">
-                    <Icon name="solar:history-bold" size="32" />
+            <NuxtLink v-if="oldestPost?.post" :to="`/blog/${oldestPost.post.slug}`"
+                class="p-5 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
+                <div
+                    class="w-12 h-12 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-warning/10 text-warning">
+                    <Icon name="solar:history-bold" size="24" />
                 </div>
-                <div class="mt-4">
-                    <h3 class="text-sm font-medium uppercase tracking-wider opacity-60">Oldest Post</h3>
-                     <div class="text-xl font-bold mt-2 line-clamp-1">
+                <div class="mt-2">
+                    <h3 class="text-xs font-medium uppercase tracking-wider opacity-60">Oldest Post</h3>
+                    <div class="text-base font-bold mt-1 line-clamp-1">
                         {{ new Date(oldestPost.post.publishedAt).toLocaleDateString('en-GB',{
                             day: 'numeric',
                             month: 'short',
                             year: 'numeric'
                         }) }}
                     </div>
-                     <p class="mt-2 text-lg font-medium group-hover:text-primary transition-colors line-clamp-2">{{ oldestPost.post.title }}</p>
+                    <p class="mt-1 text-base font-medium group-hover:text-primary transition-colors line-clamp-2">{{
+                        oldestPost.post.title }}</p>
                 </div>
             </NuxtLink>
 
             <!-- Youngest Post -->
-            <NuxtLink v-if="youngestPost?.post" :to="`/blog/${youngestPost.post.slug}`" class="p-8 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
-                 <div class="w-14 h-14 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-success/10 text-success">
-                    <Icon name="solar:calendar-add-bold" size="32" />
+            <NuxtLink v-if="youngestPost?.post" :to="`/blog/${youngestPost.post.slug}`"
+                class="p-5 rounded-3xl bg-base-200 border border-base-200 hover:border-base-300 hover:shadow-xl transition-all duration-300 flex flex-col justify-between h-full aspect-[4/3] md:aspect-auto group">
+                <div
+                    class="w-12 h-12 rounded-2xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300 bg-success/10 text-success">
+                    <Icon name="solar:calendar-add-bold" size="24" />
                 </div>
-                <div class="mt-4">
-                    <h3 class="text-sm font-medium uppercase tracking-wider opacity-60">Newest Post</h3>
-                    <div class="text-xl font-bold mt-2 line-clamp-1">
+                <div class="mt-2">
+                    <h3 class="text-xs font-medium uppercase tracking-wider opacity-60">Newest Post</h3>
+                    <div class="text-base font-bold mt-1 line-clamp-1">
                         {{ new Date(youngestPost.post.publishedAt).toLocaleDateString('en-GB',{
                             day: 'numeric',
                             month: 'short',
                             year: 'numeric'
                         }) }}
                     </div>
-                    <p class="mt-2 text-lg font-medium group-hover:text-primary transition-colors line-clamp-2">{{ youngestPost.post.title }}</p>
+                    <p class="mt-1 text-base font-medium group-hover:text-primary transition-colors line-clamp-2">{{
+                        youngestPost.post.title }}</p>
                 </div>
             </NuxtLink>
 

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -23,7 +23,7 @@ const currentSection = computed(() => {
 </script>
 <template>
     <div class="flex flex-col md:flex-row gap-8  py-6 md:p-6  ">
-        <div class="h-max w-1/3 md:sticky md:top-12">
+        <div class="h-max w-1/3 md:sticky md:top-28">
             <div class="relative">
                 <div class="absolute  z-1 -bottom-0">
                     <span
@@ -70,30 +70,17 @@ const currentSection = computed(() => {
             </div>
         </div>
         <div class="w-2/2">
-            <h1 ref='intro' class="font-semibold  text-6xl xl:text-7xl font-display">Hi, I'm <span
+            <h1 ref='intro' class="font-semibold  text-6xl xl:text-7xl font-display">Hello, I'm <span
                     class="text-primary underline font-medium ">Michael</span>
-                A Frontend Web
+                A Web
                 developer.
             </h1>
 
 
 
-            <p class="text-lg leading-8 mt-6 font-normal-weight opacity-75">I am a Full stack web developer at
-                <NuxtLink @click="playSound" to="https://mihma.com" target="_blank">
-
-                    <span
-                        class="py-0 px-2 rounded-lg bg-base-200  inline-flex shadow-xl  border-1 border-dashed text-sm border-base-content/30 font-mono hover:border-solid hover:border-primary transition-all !opacity-100">
-
-                        MIHMA
-                    </span>
-                </NuxtLink> and <NuxtLink @click="playSound" to="https://newvcreatives.com" target="_blank">
-
-                    <span
-                        class="py-0 px-2 rounded-lg bg-base-200  inline-flex shadow-xl  border-1 border-dashed text-sm border-base-content/30 font-mono hover:border-solid hover:border-primary transition-all !opacity-100">
-
-                        New Vision Creatives
-                    </span>
-                </NuxtLink>. <br> Over the years I have contributed to open source, including <NuxtLink
+            <p class="text-lg leading-8 mt-6 font-normal-weight opacity-75">I am a <b>Full stack web developer</b> with
+                a passion for building beautiful and robust web projects. <br> Over the years I have contributed to open
+                source, including <NuxtLink
                     @click="playSound" to="https://github.com/biomejs/biome/pull/2230" target="_blank">
 
                     <span class="  inline-flex gap-x-2 items-center">
@@ -125,7 +112,7 @@ const currentSection = computed(() => {
                         </span>
 
                     </span>
-                </NuxtLink> on how it is done.. Here are quick links to my Github &
+                </NuxtLink> on how it is done. <br> Here are quick links to my Github &
                 social media
             </p>
 
@@ -151,11 +138,13 @@ const currentSection = computed(() => {
 
                     <Icon name="simple-icons:discord" size="24" class="" />
                 </div>
-                <div
-                    class="!p-3  hover:shadow-primary/30 rounded-lg bg-base-200  inline-flex shadow-xl border-1 border-dashed text-sm border-base-content/30 font-mono hover:border-solid hover:border-primary transition-all">
+                <NuxtLink to="mailto:hello@michaelnji.codes">
+                    <div
+                        class="!p-3  hover:shadow-primary/30 rounded-lg bg-base-200  inline-flex shadow-xl border-1 border-dashed text-sm border-base-content/30 font-mono hover:border-solid hover:border-primary transition-all">
 
-                    <Icon name="simple-icons:gmail" size="24" class="" />
-                </div>
+                        <Icon name="simple-icons:gmail" size="24" class="" />
+                    </div>
+                </NuxtLink>
             </div>
 
             <div class="mt-16">


### PR DESCRIPTION
## Summary by Sourcery

Tighten the blog stats and hero layouts while making the site header sticky for improved readability and navigation.

New Features:
- Make the main site header sticky at the top of the viewport.
- Link the email (Gmail) icon in the hero section to a mailto contact address.

Enhancements:
- Compact the blog stats grid with smaller gaps, cards, and typography for a denser layout.
- Adjust the hero section copy and sticky offset to refine the introduction and layout behavior.